### PR TITLE
updates for excellent a1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,16 @@ jobs:
           pip install build
           pip install -e .
 
+      - name: Set build metadata with lib-version
+        id: build_meta
+        run: |
+          # Get metadata and set as environment variables
+          lib-version version metadata >> $GITHUB_ENV
+          
+          # Also display for logging
+          echo "Build metadata from lib-version:"
+          lib-version version metadata
+
       - name: Build package
         run: |
           # For tagged builds (vX.Y or vX.Y.Z), the builder will handle version creation
@@ -87,7 +97,8 @@ jobs:
         id: pre_version
         run: |
           NEXT_VERSION=$(lib-version version next)
-          PRE_VERSION="${NEXT_VERSION}-pre"
+          # Use timestamp from lib-version metadata (already in env)
+          PRE_VERSION="${NEXT_VERSION}-pre-${{ env.timestamp }}"
           echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
           echo "pre_version=$PRE_VERSION" >> $GITHUB_OUTPUT
           echo "Pre-release version: $PRE_VERSION"


### PR DESCRIPTION
Added to the cli an entry to get the timestamp and used it in the release to pass this requirement; 


- The automation supports to release multiple versions of the same pre-release, like 1.2.3-pre-<n> ,
in which n is an automatically set counter or date.
The concrete format is up to you. Some ecosystems have built-in support: Maven automatically adds a timestamp
when version 1.2.3-SNAPSHOT is released or Poetry can auto-count pre-releases with a version option.


not sure if I correctly implemented it in the release so please review that with caution, the action works